### PR TITLE
Printing improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
   
   client:
-    name: Build and push client image
+    name: Build and push frontend image
     uses: ./.github/workflows/step-ci-docker-build-push.yml
     with:
       CONTEXT: frontend

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,5 +23,6 @@ RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore 4-presentation
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
+ENV TZ=Etc/UTC
 COPY --from=build /app ./
 ENTRYPOINT ["dotnet", "Resto.Api.dll"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,5 +23,5 @@ RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore 4-presentation
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
-copy --from=build /app ./
+COPY --from=build /app ./
 ENTRYPOINT ["dotnet", "Resto.Api.dll"]

--- a/api/src/3-infrastructure/Integrations/TicketPrinting/DependencyInjectionExtensions.cs
+++ b/api/src/3-infrastructure/Integrations/TicketPrinting/DependencyInjectionExtensions.cs
@@ -7,7 +7,7 @@ public static class DependencyInjectionExtensions
 {
 	public static IServiceCollection AddTicketPrinting(this IServiceCollection services)
 	{
-		services.AddSingleton<ITicketPrintingService, TicketPrintingService>();
+		services.AddScoped<ITicketPrintingService, TicketPrintingService>();
 		
 		return services;
 	}

--- a/api/src/3-infrastructure/Integrations/TicketPrinting/FileStreamPrinter.cs
+++ b/api/src/3-infrastructure/Integrations/TicketPrinting/FileStreamPrinter.cs
@@ -1,0 +1,35 @@
+using ESCPOS_NET;
+
+namespace Resto.Infrastructure.Integrations.TicketPrinting;
+
+/// <summary>
+/// This implementation of BasePrinter copies over the implementation of FilePrinter
+/// in the ESCPOS_NET library, but changes the creation of the FileStream to specify
+/// write-only and WriteThrough since it resulted in faulty prints.
+/// Once this issue is fixed upstream, this implementation should be made obsolete.
+/// </summary>
+internal sealed class FileStreamPrinter : BasePrinter
+{
+    private readonly FileStream _fileStream;
+
+    public FileStreamPrinter(string filePath, bool createIfNotExists = false) : base()
+    {
+        _fileStream = new FileStream(
+            filePath,
+            createIfNotExists ? FileMode.OpenOrCreate : FileMode.Open,
+            FileAccess.Write,
+            FileShare.None,
+            4096,
+            FileOptions.WriteThrough);
+        Writer = new BinaryWriter(_fileStream);
+        // Reader = new BinaryReader(_fileStream);
+    }
+
+    ~FileStreamPrinter() => Dispose(false);
+
+    protected override void OverridableDispose()
+    {
+        _fileStream.Close();
+        _fileStream?.Dispose();
+    }
+}

--- a/api/src/3-infrastructure/Integrations/TicketPrinting/TicketPrintingService.cs
+++ b/api/src/3-infrastructure/Integrations/TicketPrinting/TicketPrintingService.cs
@@ -14,7 +14,7 @@ internal class TicketPrintingService : ITicketPrintingService
 
 	private readonly ILogger<TicketPrintingService> _logger;
 	private readonly ITicketPrintingConfiguration _configuration;
-	private readonly FilePrinter _printer;
+	private readonly FileStreamPrinter _printer;
 	private readonly byte[] _headerImage;
 
 	public TicketPrintingService(ILogger<TicketPrintingService> logger, ITicketPrintingConfiguration configuration)
@@ -27,7 +27,7 @@ internal class TicketPrintingService : ITicketPrintingService
 			_logger.LogDebug("Printer path is available, trying to set up connection");
 			if (File.Exists(_configuration.PrinterPath))
 			{
-				_printer = new FilePrinter(filePath: _configuration.PrinterPath, createIfNotExists: false);
+				_printer = new FileStreamPrinter(filePath: _configuration.PrinterPath, createIfNotExists: false);
 				
 				_logger.LogInformation("Set up printer connection");
 			}


### PR DESCRIPTION
* refactor the printing service to scoped to prepare for "dynamic" discovery later on 
* add a temporary printer implementation to fix the faulty duplicate printing issue 
* clean up the service with best practices (static methods, concrete types, ...)
* format the timestamp as local on the printed ticket 