### PR TITLE
Delete orders

### DIFF
--- a/api/src/2-application/Application/Modules/Orders/DeleteOrders.cs
+++ b/api/src/2-application/Application/Modules/Orders/DeleteOrders.cs
@@ -1,0 +1,36 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Resto.Application.Common.Persistence;
+
+namespace Resto.Application.Modules.Orders;
+
+public static class DeleteOrders
+{
+    public sealed record Request : IRequest;
+
+    internal sealed class Handler : IRequestHandler<Request>
+    {
+        #region construction
+
+        private readonly ILogger<Handler> _logger;
+        private readonly IAppDbContext _dbContext;
+
+        public Handler(ILogger<Handler> logger, IAppDbContext dbContext)
+        {
+            _logger = logger;
+            _dbContext = dbContext;
+        }
+
+        #endregion
+
+        public async Task Handle(Request request, CancellationToken cancellationToken)
+        {
+            _logger.LogWarning("Deleting all orders");
+
+            await _dbContext.Orders
+                .ExecuteDeleteAsync(CancellationToken.None);
+            _logger.LogInformation("Removed all orders from database");
+        }
+    }
+}

--- a/api/src/4-presentation/Api/Controllers/OrdersController.cs
+++ b/api/src/4-presentation/Api/Controllers/OrdersController.cs
@@ -27,4 +27,11 @@ public sealed class OrdersController : ApiControllerBase
 	public async Task<ActionResult<GetOrderStatistics.Response>> GetOrderStatistics(
 		[FromQuery] GetOrderStatistics.Request request)
 		=> await Mediator.Send(request);
+
+	[HttpDelete]
+	public async Task<IActionResult> DeleteOrders()
+	{
+		await Mediator.Send(new DeleteOrders.Request());
+		return NoContent();
+	}
 }

--- a/frontend/spa/src/components/order-history/DeleteOrdersModal.vue
+++ b/frontend/spa/src/components/order-history/DeleteOrdersModal.vue
@@ -1,0 +1,39 @@
+<template>
+  <DeleteModal
+    name=""
+    entity="Bestellingen"
+    :is-loading="isLoading"
+    :is-error="isError"
+    @close="emit('close')"
+    @delete="triggerMutation"
+  />
+</template>
+
+<script setup>
+import DeleteModal from '@/components/manage/common/DeleteModal.vue';
+import { useMutation, useQueryClient } from '@tanstack/vue-query';
+import OrdersService from '@/services/resto-api/orders.service.js';
+import { QUERY_KEYS } from '@/utilities/constants.js';
+import { useToast } from 'vue-toastification';
+
+const toast = useToast();
+
+const emit = defineEmits(['close']);
+const queryClient = useQueryClient();
+const {
+  isLoading,
+  isError,
+  mutate: triggerMutation,
+} = useMutation({
+  mutationFn: () => OrdersService.delete(),
+  onSuccess: () => {
+    toast.success('Bestellingen verwijderd');
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.ORDERS,
+    });
+    emit('close');
+  },
+});
+</script>
+
+<style scoped lang="scss"></style>

--- a/frontend/spa/src/components/order-history/OrderHistory.vue
+++ b/frontend/spa/src/components/order-history/OrderHistory.vue
@@ -5,8 +5,20 @@
     </div>
     <div class="right">
       <LoadingIndicator v-if="loading">{{ loadingLabel }}</LoadingIndicator>
+
+      <button
+        type="button"
+        class="btn-danger btn-icon"
+        @click="showDeleteModal = true"
+      >
+        <i class="icon-trash" /> Alle bestellingen wissen
+      </button>
     </div>
   </div>
+  <DeleteOrdersModal
+    v-if="showDeleteModal"
+    @close="showDeleteModal = false"
+  />
 
   <div v-if="isError">
     <div>Er liep iets mis bij het ophalen van de bestellingen, probeer het later opnieuw.</div>
@@ -34,10 +46,11 @@
 
 <script setup>
 import { useOrdersQuery } from '@/composables/queries';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import LoadingIndicator from '@/components/common/LoadingIndicator.vue';
 import LoadNextPage from '@/components/common/LoadNextPage.vue';
 import OrderHistoryListItem from '@/components/order-history/OrderHistoryListItem.vue';
+import DeleteOrdersModal from '@/components/order-history/DeleteOrdersModal.vue';
 
 const {
   orders,
@@ -56,6 +69,10 @@ const loadingLabel = computed(() => {
   else if (isFetching.value) return 'Bestellingen bijwerken';
   return '';
 });
+
+//#region delete
+const showDeleteModal = ref(false);
+//#endregion
 </script>
 
 <style scoped lang="scss">
@@ -64,6 +81,12 @@ const loadingLabel = computed(() => {
 
 .header {
   @include layout.flex-row-space-between;
+  margin-bottom: 1rem;
+
+  .right {
+    display: flex;
+    gap: 1rem;
+  }
 }
 
 h2 {

--- a/frontend/spa/src/services/resto-api/orders.service.js
+++ b/frontend/spa/src/services/resto-api/orders.service.js
@@ -20,5 +20,10 @@ class OrdersService {
     // await new Promise((r) => setTimeout(r, 1000));
     return restoApi.get(`/orders/stats`);
   }
+
+  delete() {
+    return restoApi.delete('/orders');
+  }
 }
+
 export default new OrdersService();


### PR DESCRIPTION
Allow clearing all orders from the database: this can help when testing the setup and clearing all test input before actually starting to take orders